### PR TITLE
Add defaultVersion to typings of BackendOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ declare namespace I18NextLocalStorageBackend {
     prefix?: string;
     expirationTime?: number;
     versions?: { [key: string]: string };
+    defaultVersion?: string;
     store?: any
   }
 


### PR DESCRIPTION
The documentation and code indicate a `defaultVersion` option for this backend, so the typescript definitions should have them as well.