### PR TITLE
Ssr fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ node_modules
 node_modules/**/*
 coverage/**/*
 dist/**/*
+
+# JetBrains IDE's
+.idea

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ i18next
   versions: {},
 
   // can be either window.localStorage or window.sessionStorage. Default: window.localStorage
-  store: window.localStorage
+  store: typeof window !== 'undefined' ? window.localStorage : null
 };
 ```
 
@@ -66,6 +66,7 @@ i18next
 
 - Passing in a `defaultVersion` string (ex.: `version: 'v1.2'`) will act as if you applied a version to all languages using `versions` option.
 
+- The test on window makes this package available for SSR environments like NextJS
 
 ## IMPORTANT ADVICE for the usage in combination with saveMissing/updateMissing
 

--- a/i18nextLocalStorageBackend.js
+++ b/i18nextLocalStorageBackend.js
@@ -102,7 +102,7 @@
       expirationTime: 7 * 24 * 60 * 60 * 1000,
       defaultVersion: undefined,
       versions: {},
-      store: window.localStorage
+      store: typeof window !== 'undefined' ? window.localStorage : null
     };
   }
 


### PR DESCRIPTION
A simple case of testing the Window variable before use. 
If not 'window' is available, like in SSR situations, then _null_ is returned for the Store.
The function using the store will return undefined, but this is ServerSide. 
ClientSide will have the 'window' variable and works as before. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [X] documentation is changed or added